### PR TITLE
README.md: Update URL for kernel-handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ The cross compiled armel kernel is confirmed to working on:
 Credit
 ----
 
-- https://kernel-handbook.debian.net
+- https://kernel-team.pages.debian.net/kernel-handbook/


### PR DESCRIPTION
kernel-handbook.debian.net was only a temporary home for the Kernel Handbook.